### PR TITLE
Update rack-protection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     os (0.9.6)
     public_suffix (2.0.5)
     rack (1.5.5)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -148,5 +148,4 @@ DEPENDENCIES
   twitter
 
 BUNDLED WITH
-   1.14.5
-
+   1.16.1


### PR DESCRIPTION
Ran bundle `update rack-protection` to fix vulnerability. https://github.com/gctools-outilsgc/gcdashboard/network/dependencies

Running just `bundle update` updates lot more packages, but I decided to wait before updating everything.